### PR TITLE
Add Flask server for ACE Step

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
    ```
    
    You can override the port by setting the `PORT` environment variable.
+   To choose which GPU to run on, set `DEVICE_ID` (defaults to `0`). If no GPU is
+   available the server will fall back to CPU.
 
 3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns the generated audio file.
 

--- a/README.md
+++ b/README.md
@@ -10,18 +10,20 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
    pip install -r requirements.txt
    ```
 
-2. Start the server:
+2. Start the server (defaults to port 8000):
 
    ```bash
    python ace_step_server.py
    ```
+   
+   You can override the port by setting the `PORT` environment variable.
 
 3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns the generated audio file.
 
 ## Endpoint Example
 
 ```bash
-curl -X POST http://localhost:5000/generate \
+curl -X POST http://localhost:8000/generate \
      -H 'Content-Type: application/json' \
      -d '{"prompt": "upbeat pop", "lyrics": "[verse]\nHello world", "length": 5}' \
      --output song.flac

--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ curl -X POST http://localhost:8000/generate \
      -d '{"prompt": "upbeat pop", "lyrics": "[verse]\nHello world", "length": 5}' \
      --output song.flac
 ```
+
+Alternatively, you can call the server from Python using the provided script:
+
+```bash
+python call_api.py --prompt "upbeat pop" --lyrics "[verse]\nHello world" --length 5 --output song.flac
+```

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
    `torch.compile()` and overlapped decoding are enabled by default. Set
    `TORCH_COMPILE=0` or `OVERLAPPED_DECODE=0` to disable these features.
 
-3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns the generated audio in FLAC format.
+3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns a JSON object with the audio base64 encoded under the `audio_base64` key.
 
 ## Endpoint Example
 
@@ -30,7 +30,7 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
 curl -X POST http://localhost:8000/generate \
      -H 'Content-Type: application/json' \
      -d '{"prompt": "upbeat pop", "lyrics": "[verse]\nHello world", "length": 5}' \
-     --output song.flac
+     | jq -r .audio_base64 | base64 -d > song.flac
 ```
 
 Alternatively, you can call the server from Python using the provided script:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
    You can override the port by setting the `PORT` environment variable.
    To choose which GPU to run on, set `DEVICE_ID` (defaults to `0`). If no GPU is
    available the server will fall back to CPU.
+   Set `TORCH_COMPILE=1` to enable `torch.compile()` for faster inference and
+   `OVERLAPPED_DECODE=1` to use overlapped decoding for long songs.
 
 3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns the generated audio file.
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,29 @@
+# ACE Step Flask API
+
+This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) music generation model through a simple Flask server.
+
+## Usage
+
+1. Install dependencies. The ACE Step package can be installed from GitHub:
+
+   ```bash
+   pip install git+https://github.com/ace-step/ACE-Step.git
+   pip install Flask
+   ```
+
+2. Start the server:
+
+   ```bash
+   python ace_step_server.py
+   ```
+
+3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns the generated audio file.
+
+## Endpoint Example
+
+```bash
+curl -X POST http://localhost:5000/generate \
+     -H 'Content-Type: application/json' \
+     -d '{"prompt": "upbeat pop", "lyrics": "[verse]\nHello world", "length": 5}' \
+     --output song.flac
+```

--- a/README.md
+++ b/README.md
@@ -4,11 +4,10 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
 
 ## Usage
 
-1. Install dependencies. The ACE Step package can be installed from GitHub:
+1. Install dependencies using `requirements.txt`:
 
    ```bash
-   pip install git+https://github.com/ace-step/ACE-Step.git
-   pip install Flask
+   pip install -r requirements.txt
    ```
 
 2. Start the server:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
 
 ## Usage
 
-1. Install dependencies using `requirements.txt`:
+1. Install dependencies using `requirements.txt` (FFmpeg must be available to enable MP3 export):
 
    ```bash
    pip install -r requirements.txt
@@ -22,7 +22,7 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
    `torch.compile()` and overlapped decoding are enabled by default. Set
    `TORCH_COMPILE=0` or `OVERLAPPED_DECODE=0` to disable these features.
 
-3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns the generated audio file.
+3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns an MP3 audio file.
 
 ## Endpoint Example
 
@@ -30,11 +30,11 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
 curl -X POST http://localhost:8000/generate \
      -H 'Content-Type: application/json' \
      -d '{"prompt": "upbeat pop", "lyrics": "[verse]\nHello world", "length": 5}' \
-     --output song.flac
+     --output song.mp3
 ```
 
 Alternatively, you can call the server from Python using the provided script:
 
 ```bash
-python call_api.py --prompt "upbeat pop" --lyrics "[verse]\nHello world" --length 5 --output song.flac
+python call_api.py --prompt "upbeat pop" --lyrics "[verse]\nHello world" --length 5 --output song.mp3
 ```

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
    You can override the port by setting the `PORT` environment variable.
    To choose which GPU to run on, set `DEVICE_ID` (defaults to `0`). If no GPU is
    available the server will fall back to CPU.
-   Set `TORCH_COMPILE=1` to enable `torch.compile()` for faster inference and
-   `OVERLAPPED_DECODE=1` to use overlapped decoding for long songs.
+   `torch.compile()` and overlapped decoding are enabled by default. Set
+   `TORCH_COMPILE=0` or `OVERLAPPED_DECODE=0` to disable these features.
 
 3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns the generated audio file.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
 
 ## Usage
 
-1. Install dependencies using `requirements.txt` (FFmpeg must be available to enable MP3 export):
+1. Install dependencies using `requirements.txt`:
 
    ```bash
    pip install -r requirements.txt
@@ -22,7 +22,7 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
    `torch.compile()` and overlapped decoding are enabled by default. Set
    `TORCH_COMPILE=0` or `OVERLAPPED_DECODE=0` to disable these features.
 
-3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns an MP3 audio file.
+3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns the generated audio in FLAC format.
 
 ## Endpoint Example
 
@@ -30,11 +30,11 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
 curl -X POST http://localhost:8000/generate \
      -H 'Content-Type: application/json' \
      -d '{"prompt": "upbeat pop", "lyrics": "[verse]\nHello world", "length": 5}' \
-     --output song.mp3
+     --output song.flac
 ```
 
 Alternatively, you can call the server from Python using the provided script:
 
 ```bash
-python call_api.py --prompt "upbeat pop" --lyrics "[verse]\nHello world" --length 5 --output song.mp3
+python call_api.py --prompt "upbeat pop" --lyrics "[verse]\nHello world" --length 5 --output song.flac
 ```

--- a/ace_step_server.py
+++ b/ace_step_server.py
@@ -1,4 +1,5 @@
 from flask import Flask, request, send_file, jsonify
+from pydub import AudioSegment
 from acestep.pipeline_ace_step import ACEStepPipeline
 import os
 
@@ -38,7 +39,11 @@ def generate_song():
         return jsonify({'error': 'generation failed'}), 500
 
     audio_path = output_paths[0]
-    return send_file(audio_path, as_attachment=True)
+    mp3_path = os.path.splitext(audio_path)[0] + ".mp3"
+    # Convert the generated FLAC to MP3. Requires ffmpeg to be installed.
+    audio = AudioSegment.from_file(audio_path)
+    audio.export(mp3_path, format="mp3")
+    return send_file(mp3_path, as_attachment=True)
 
 if __name__ == '__main__':
     # Use PORT env var if provided, otherwise default to 8000 to avoid

--- a/ace_step_server.py
+++ b/ace_step_server.py
@@ -7,12 +7,12 @@ app = Flask(__name__)
 # Initialize the ACE Step pipeline. The checkpoint will be downloaded on first use.
 # If a GPU device is available, you can choose which one to use via the
 # DEVICE_ID environment variable (defaults to 0).
-def env_flag(name: str) -> bool:
-    return os.environ.get(name, "0").lower() in ("1", "true", "yes")
+def env_flag(name: str, default: str = "0") -> bool:
+    return os.environ.get(name, default).lower() in ("1", "true", "yes")
 
 device_id = int(os.environ.get("DEVICE_ID", 0))
-torch_compile = env_flag("TORCH_COMPILE")
-overlapped_decode = env_flag("OVERLAPPED_DECODE")
+torch_compile = env_flag("TORCH_COMPILE", default="1")
+overlapped_decode = env_flag("OVERLAPPED_DECODE", default="1")
 
 pipeline = ACEStepPipeline(
     device_id=device_id,

--- a/ace_step_server.py
+++ b/ace_step_server.py
@@ -28,5 +28,7 @@ def generate_song():
     return send_file(audio_path, as_attachment=True)
 
 if __name__ == '__main__':
-    port = int(os.environ.get('PORT', 5000))
+    # Use PORT env var if provided, otherwise default to 8000 to avoid
+    # clashing with other local services that may use port 5000.
+    port = int(os.environ.get('PORT', 8000))
     app.run(host='0.0.0.0', port=port)

--- a/ace_step_server.py
+++ b/ace_step_server.py
@@ -1,6 +1,7 @@
-from flask import Flask, request, send_file, jsonify
+from flask import Flask, request, jsonify
 from acestep.pipeline_ace_step import ACEStepPipeline
 import os
+import base64
 
 app = Flask(__name__)
 
@@ -38,7 +39,10 @@ def generate_song():
         return jsonify({'error': 'generation failed'}), 500
 
     audio_path = output_paths[0]
-    return send_file(audio_path, as_attachment=True)
+    with open(audio_path, "rb") as f:
+        audio_bytes = f.read()
+    audio_b64 = base64.b64encode(audio_bytes).decode("utf-8")
+    return jsonify({"audio_base64": audio_b64})
 
 if __name__ == '__main__':
     # Use PORT env var if provided, otherwise default to 8000 to avoid

--- a/ace_step_server.py
+++ b/ace_step_server.py
@@ -7,8 +7,18 @@ app = Flask(__name__)
 # Initialize the ACE Step pipeline. The checkpoint will be downloaded on first use.
 # If a GPU device is available, you can choose which one to use via the
 # DEVICE_ID environment variable (defaults to 0).
+def env_flag(name: str) -> bool:
+    return os.environ.get(name, "0").lower() in ("1", "true", "yes")
+
 device_id = int(os.environ.get("DEVICE_ID", 0))
-pipeline = ACEStepPipeline(device_id=device_id)
+torch_compile = env_flag("TORCH_COMPILE")
+overlapped_decode = env_flag("OVERLAPPED_DECODE")
+
+pipeline = ACEStepPipeline(
+    device_id=device_id,
+    torch_compile=torch_compile,
+    overlapped_decode=overlapped_decode,
+)
 
 @app.route('/generate', methods=['POST'])
 def generate_song():

--- a/ace_step_server.py
+++ b/ace_step_server.py
@@ -1,0 +1,32 @@
+from flask import Flask, request, send_file, jsonify
+from acestep.pipeline_ace_step import ACEStepPipeline
+import os
+
+app = Flask(__name__)
+
+# Initialize the ACE Step pipeline. The checkpoint will be downloaded on first use.
+pipeline = ACEStepPipeline()
+
+@app.route('/generate', methods=['POST'])
+def generate_song():
+    data = request.get_json(force=True)
+    prompt = data.get('prompt', '')
+    lyrics = data.get('lyrics', '')
+    length = float(data.get('length', 60))
+
+    # Call the ACE Step pipeline. It returns a list of generated audio file paths.
+    output_paths = pipeline(
+        audio_duration=length,
+        prompt=prompt,
+        lyrics=lyrics,
+    )
+
+    if not output_paths:
+        return jsonify({'error': 'generation failed'}), 500
+
+    audio_path = output_paths[0]
+    return send_file(audio_path, as_attachment=True)
+
+if __name__ == '__main__':
+    port = int(os.environ.get('PORT', 5000))
+    app.run(host='0.0.0.0', port=port)

--- a/ace_step_server.py
+++ b/ace_step_server.py
@@ -5,7 +5,10 @@ import os
 app = Flask(__name__)
 
 # Initialize the ACE Step pipeline. The checkpoint will be downloaded on first use.
-pipeline = ACEStepPipeline()
+# If a GPU device is available, you can choose which one to use via the
+# DEVICE_ID environment variable (defaults to 0).
+device_id = int(os.environ.get("DEVICE_ID", 0))
+pipeline = ACEStepPipeline(device_id=device_id)
 
 @app.route('/generate', methods=['POST'])
 def generate_song():

--- a/ace_step_server.py
+++ b/ace_step_server.py
@@ -1,5 +1,4 @@
 from flask import Flask, request, send_file, jsonify
-from pydub import AudioSegment
 from acestep.pipeline_ace_step import ACEStepPipeline
 import os
 
@@ -39,11 +38,7 @@ def generate_song():
         return jsonify({'error': 'generation failed'}), 500
 
     audio_path = output_paths[0]
-    mp3_path = os.path.splitext(audio_path)[0] + ".mp3"
-    # Convert the generated FLAC to MP3. Requires ffmpeg to be installed.
-    audio = AudioSegment.from_file(audio_path)
-    audio.export(mp3_path, format="mp3")
-    return send_file(mp3_path, as_attachment=True)
+    return send_file(audio_path, as_attachment=True)
 
 if __name__ == '__main__':
     # Use PORT env var if provided, otherwise default to 8000 to avoid

--- a/call_api.py
+++ b/call_api.py
@@ -4,9 +4,18 @@ import requests
 
 def main():
     parser = argparse.ArgumentParser(description="Call the ACE Step service")
-    parser.add_argument("--prompt", required=True, help="text prompt for style")
+    parser.add_argument(
+        "--prompt",
+        default="upbeat pop",
+        help="text prompt for style (defaults to 'upbeat pop')",
+    )
     parser.add_argument("--lyrics", default="", help="lyrics in ACE Step format")
-    parser.add_argument("--length", type=float, default=60, help="song length in seconds")
+    parser.add_argument(
+        "--length",
+        type=float,
+        default=5,
+        help="song length in seconds (defaults to 5)",
+    )
     parser.add_argument("--output", default="song.flac", help="output audio filename")
     parser.add_argument(
         "--url",

--- a/call_api.py
+++ b/call_api.py
@@ -1,0 +1,29 @@
+import argparse
+import requests
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Call the ACE Step service")
+    parser.add_argument("--prompt", required=True, help="text prompt for style")
+    parser.add_argument("--lyrics", default="", help="lyrics in ACE Step format")
+    parser.add_argument("--length", type=float, default=60, help="song length in seconds")
+    parser.add_argument("--output", default="song.flac", help="output audio filename")
+    parser.add_argument(
+        "--url",
+        default="http://localhost:8000/generate",
+        help="URL of the /generate endpoint",
+    )
+    args = parser.parse_args()
+
+    payload = {"prompt": args.prompt, "lyrics": args.lyrics, "length": args.length}
+    r = requests.post(args.url, json=payload)
+    if r.status_code != 200:
+        raise SystemExit(f"Request failed: {r.status_code} {r.text}")
+
+    with open(args.output, "wb") as f:
+        f.write(r.content)
+    print(f"Saved song to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/call_api.py
+++ b/call_api.py
@@ -1,4 +1,5 @@
 import argparse
+import base64
 import requests
 
 
@@ -29,8 +30,14 @@ def main():
     if r.status_code != 200:
         raise SystemExit(f"Request failed: {r.status_code} {r.text}")
 
+    data = r.json()
+    audio_b64 = data.get("audio_base64")
+    if not audio_b64:
+        raise SystemExit("Response missing audio data")
+
+    audio_bytes = base64.b64decode(audio_b64)
     with open(args.output, "wb") as f:
-        f.write(r.content)
+        f.write(audio_bytes)
     print(f"Saved song to {args.output}")
 
 

--- a/call_api.py
+++ b/call_api.py
@@ -16,7 +16,7 @@ def main():
         default=5,
         help="song length in seconds (defaults to 5)",
     )
-    parser.add_argument("--output", default="song.flac", help="output audio filename")
+    parser.add_argument("--output", default="song.mp3", help="output audio filename")
     parser.add_argument(
         "--url",
         default="http://localhost:8000/generate",

--- a/call_api.py
+++ b/call_api.py
@@ -16,7 +16,7 @@ def main():
         default=5,
         help="song length in seconds (defaults to 5)",
     )
-    parser.add_argument("--output", default="song.mp3", help="output audio filename")
+    parser.add_argument("--output", default="song.flac", help="output audio filename")
     parser.add_argument(
         "--url",
         default="http://localhost:8000/generate",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ Flask
 # Install ACE Step directly from GitHub
 git+https://github.com/ace-step/ACE-Step.git
 requests
-pydub

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask
 # Install ACE Step directly from GitHub
 git+https://github.com/ace-step/ACE-Step.git
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+# Install ACE Step directly from GitHub
+git+https://github.com/ace-step/ACE-Step.git

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask
 # Install ACE Step directly from GitHub
 git+https://github.com/ace-step/ACE-Step.git
 requests
+pydub


### PR DESCRIPTION
## Summary
- add `ace_step_server.py` to provide a Flask interface to the ACE Step pipeline
- document installation and usage in `README.md`

## Testing
- `python -m py_compile ace_step_server.py`

------
https://chatgpt.com/codex/tasks/task_e_68585d997c388323821d86a9fc21008d