### PR TITLE
Unload model after each request

### DIFF
--- a/ace_step_server.py
+++ b/ace_step_server.py
@@ -2,24 +2,19 @@ from flask import Flask, request, jsonify
 from acestep.pipeline_ace_step import ACEStepPipeline
 import os
 import base64
+import gc
+import torch
 
 app = Flask(__name__)
 
-# Initialize the ACE Step pipeline. The checkpoint will be downloaded on first use.
-# If a GPU device is available, you can choose which one to use via the
-# DEVICE_ID environment variable (defaults to 0).
+# Environment flags controlling ACE Step behaviour. The checkpoint will be
+# downloaded on first use. DEVICE_ID chooses which GPU to use (defaults to 0).
 def env_flag(name: str, default: str = "0") -> bool:
     return os.environ.get(name, default).lower() in ("1", "true", "yes")
 
 device_id = int(os.environ.get("DEVICE_ID", 0))
 torch_compile = env_flag("TORCH_COMPILE", default="1")
 overlapped_decode = env_flag("OVERLAPPED_DECODE", default="1")
-
-pipeline = ACEStepPipeline(
-    device_id=device_id,
-    torch_compile=torch_compile,
-    overlapped_decode=overlapped_decode,
-)
 
 @app.route('/generate', methods=['POST'])
 def generate_song():
@@ -28,12 +23,26 @@ def generate_song():
     lyrics = data.get('lyrics', '')
     length = float(data.get('length', 60))
 
+    # Load the pipeline on demand so the model does not remain resident in
+    # memory after the request completes.
+    pipeline = ACEStepPipeline(
+        device_id=device_id,
+        torch_compile=torch_compile,
+        overlapped_decode=overlapped_decode,
+    )
+
     # Call the ACE Step pipeline. It returns a list of generated audio file paths.
     output_paths = pipeline(
         audio_duration=length,
         prompt=prompt,
         lyrics=lyrics,
     )
+
+    # Explicitly release memory used by the pipeline.
+    del pipeline
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
 
     if not output_paths:
         return jsonify({'error': 'generation failed'}), 500


### PR DESCRIPTION
## Summary
- instantiate the ACE Step pipeline inside each `/generate` call
- release GPU memory after generating a song

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68587badc5c883238955bf0ee413d6c5