### PR TITLE
Cleanup outputs after each generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ This repository exposes the [ACE Step](https://github.com/ace-step/ACE-Step) mus
    available the server will fall back to CPU.
    `torch.compile()` and overlapped decoding are enabled by default. Set
    `TORCH_COMPILE=0` or `OVERLAPPED_DECODE=0` to disable these features.
+   Generated audio files are saved temporarily and the server cleans up the
+   `outputs` directory after each request.
 
 3. Generate music by sending a POST request to `/generate` with a JSON body containing `prompt`, `lyrics` and `length` (in seconds). The server returns a JSON object with the audio base64 encoded under the `audio_base64` key.
 

--- a/ace_step_server.py
+++ b/ace_step_server.py
@@ -3,6 +3,7 @@ from acestep.pipeline_ace_step import ACEStepPipeline
 import os
 import base64
 import gc
+import shutil
 import torch
 
 app = Flask(__name__)
@@ -51,6 +52,13 @@ def generate_song():
     with open(audio_path, "rb") as f:
         audio_bytes = f.read()
     audio_b64 = base64.b64encode(audio_bytes).decode("utf-8")
+
+    outputs_dir = os.path.dirname(audio_path)
+    try:
+        shutil.rmtree(outputs_dir)
+    except Exception as e:
+        app.logger.warning(f"Failed to clean outputs directory {outputs_dir}: {e}")
+
     return jsonify({"audio_base64": audio_b64})
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- delete generated files after each /generate call
- note cleanup behavior in the README

## Testing
- `pip install -r requirements.txt` *(fails: Operation cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_6859c8e1fb748323a957ffda33305efb